### PR TITLE
Create a Retriever abstraction

### DIFF
--- a/conda/lintdb/meta.yaml
+++ b/conda/lintdb/meta.yaml
@@ -11,10 +11,12 @@ build:
 
 about:
   home: https://github.com/DeployQL/lintdb
-  license: MIT
-  license_family: MIT
+  license: Apache 2
+  license_family: Apache
   license_file: LICENSE
   summary: A multi-vector database for token level interaction.
+  description: |
+    LintDB is a multi-vector database meant for Gen AI. LintDB natively supports late interaction like colBERT and PLAID. 
 
 source:
   git_url: ../../

--- a/lintdb/CMakeLists.txt
+++ b/lintdb/CMakeLists.txt
@@ -33,6 +33,7 @@ set(
     invlists/EncodedDocument.h
     invlists/RocksdbList.h
     invlists/util.h
+    retriever/Retriever.h
     retriever/PlaidRetriever.h
     schema/forward_index_generated.h
     schema/inverted_index_generated.h

--- a/lintdb/CMakeLists.txt
+++ b/lintdb/CMakeLists.txt
@@ -9,6 +9,7 @@ set(
     invlists/RocksdbList.cpp
     invlists/util.cpp
     invlists/EncodedDocument.cpp
+    retriever/PlaidRetriever.cpp
     schema/util.cpp
 )
 
@@ -25,12 +26,14 @@ set(
     EmbeddingBlock.h
     Binarizer.h
     Encoder.h
+    SearchResult.h
     util.h
     invlists/InvertedList.h
     invlists/Iterator.h
     invlists/EncodedDocument.h
     invlists/RocksdbList.h
     invlists/util.h
+    retriever/PlaidRetriever.h
     schema/forward_index_generated.h
     schema/inverted_index_generated.h
     schema/mapping_generated.h

--- a/lintdb/Encoder.cpp
+++ b/lintdb/Encoder.cpp
@@ -64,8 +64,8 @@ namespace lintdb {
     std::vector<float> DefaultEncoder::decode_vectors(
             const gsl::span<const code_t> codes,
             const gsl::span<const residual_t> residuals,
-            const size_t num_tokens,
-            const size_t dim) const {
+            const size_t num_tokens
+        ) const {
         std::vector<float> decoded_embeddings(dim * num_tokens);
 
         for (size_t i = 0; i < num_tokens; i++) {

--- a/lintdb/Encoder.h
+++ b/lintdb/Encoder.h
@@ -28,6 +28,7 @@ namespace lintdb {
         virtual ~Encoder() = default;
 
         bool is_trained = false;
+        size_t dim;
             /**
          * Encode vectors translates the embeddings given to us in RawPassage to
          * the internal representation that we expect to see in the inverted lists.
@@ -44,8 +45,8 @@ namespace lintdb {
         virtual std::vector<float> decode_vectors(
                 const gsl::span<const code_t> codes,
                 const gsl::span<const residual_t> residuals,
-                const size_t num_tokens,
-                const size_t dim) const = 0;
+                const size_t num_tokens
+            ) const = 0;
 
         /**
          * Given a query, search for the nearest centroids.
@@ -125,8 +126,8 @@ namespace lintdb {
         std::vector<float> decode_vectors(
                 gsl::span<const code_t> codes,
                 gsl::span<const residual_t> residuals,
-                size_t num_tokens,
-                size_t dim) const override;
+                size_t num_tokens
+        ) const override;
 
         void search(
             const float* data,

--- a/lintdb/SearchOptions.h
+++ b/lintdb/SearchOptions.h
@@ -1,0 +1,31 @@
+#ifndef LINTDB_SEARCH_OPTIONS_H
+#define LINTDB_SEARCH_OPTIONS_H
+
+#include <vector>
+#include "lintdb/api.h"
+#include <stddef.h>
+
+namespace lintdb {
+/**
+ * SearchOptions enables custom searching behavior. 
+ * 
+ * These options expose ways to tradeoff recall and latency at different levels of retrieval.
+ * Searching more centroids:
+ * - decrease centroid_score_threshold and increase k_top_centroids.
+ * - increase n_probe in search()
+ * 
+ * Decreasing latency:
+ * - increase centroid_score_threshold and decrease k_top_centroids.
+ * - decrease n_probe in search()
+*/
+struct SearchOptions {
+    idx_t expected_id = -1; /// expects a document id in the return result. prints additional information during execution. useful for debugging.
+    float centroid_score_threshold = 0.45; /// the threshold for centroid scores. 
+    size_t k_top_centroids = 2; /// the number of top centroids to consider. 
+    size_t num_second_pass = 1024; /// the number of second pass candidates to consider. 
+
+    SearchOptions(): expected_id(-1) {};
+};
+}
+
+#endif

--- a/lintdb/SearchResult.h
+++ b/lintdb/SearchResult.h
@@ -1,0 +1,18 @@
+#ifndef LINTDB_SEARCH_RESULT_H
+#define LINTDB_SEARCH_RESULT_H
+
+#include "lintdb/api.h"
+
+namespace lintdb {
+    
+    /**
+     * SearchResult is a simple struct to hold the results of a search.
+     * 
+    */
+    struct SearchResult {
+        idx_t id; 
+        float score;
+    };
+}
+
+#endif

--- a/lintdb/index.cpp
+++ b/lintdb/index.cpp
@@ -17,6 +17,7 @@
 #include "lintdb/invlists/RocksdbList.h"
 #include "lintdb/plaid.h"
 #include "lintdb/schema/util.h"
+#include "lintdb/retriever/Retriever.h"
 #include <stdio.h>
 #include <json/writer.h>
 #include <json/json.h>
@@ -340,7 +341,7 @@ std::vector<SearchResult> IndexIVF::search(
     auto pid_list = std::vector<idx_t>(global_pids.begin(), global_pids.end());
 
     gsl::span<const float> query_span = gsl::span(data, n);
-    PlaidOptions plaid_options = PlaidOptions{
+    RetrieverOptions plaid_options = RetrieverOptions{
         .num_second_pass = opts.num_second_pass,
         .total_centroids_to_calculate = nlist,
         .expected_id = opts.expected_id

--- a/lintdb/index.h
+++ b/lintdb/index.h
@@ -16,6 +16,7 @@
 #include "lintdb/Encoder.h"
 #include "lintdb/SearchResult.h"
 #include "lintdb/SearchOptions.h"
+#include "lintdb/retriever/Retriever.h"
 #include "lintdb/retriever/PlaidRetriever.h"
 
 // forward declare these classes and avoid including the rocksdb headers.
@@ -194,7 +195,7 @@ struct IndexIVF {
     std::vector<rocksdb::ColumnFamilyHandle*> column_families;
 
     std::shared_ptr<Encoder> encoder;
-    std::unique_ptr<PlaidRetriever> retriever;
+    std::unique_ptr<Retriever> retriever;
 
     size_t dim; /// number of dimensions per embedding.
 

--- a/lintdb/plaid.cpp
+++ b/lintdb/plaid.cpp
@@ -38,10 +38,10 @@ float score_documents_by_codes(
 }
 
 float colbert_centroid_score(
-        std::vector<code_t>& doc_codes, // of size num_doc_tokens. one code per token.
-        std::vector<float>& centroid_scores, // of size nquery_vectors x n_centroids
-        size_t nquery_vectors,
-        size_t n_centroids,
+        const std::vector<code_t>& doc_codes, // of size num_doc_tokens. one code per token.
+        const std::vector<float>& centroid_scores, // of size nquery_vectors x n_centroids
+        const size_t nquery_vectors,
+        const size_t n_centroids,
         const idx_t doc_id) {
     std::vector<float> per_doc_approx_scores(nquery_vectors, -9999);
 

--- a/lintdb/plaid.h
+++ b/lintdb/plaid.h
@@ -31,10 +31,10 @@ std::vector<float> max_score_by_centroid(
         size_t num_centroids);
 
 float colbert_centroid_score(
-        std::vector<code_t>& doc_codes, /// codes from the document. each token is assigned a code.
-        std::vector<float>& centroid_scores, /// the score of those codes to the query.
-        size_t nquery_vectors, /// the number of query vectors.
-        size_t n_centroids, /// how many centroids there are. this may change based on how many scores we choose to calculate.
+        const std::vector<code_t>& doc_codes, /// codes from the document. each token is assigned a code.
+        const std::vector<float>& centroid_scores, /// the score of those codes to the query.
+        const size_t nquery_vectors, /// the number of query vectors.
+        const size_t n_centroids, /// how many centroids there are. this may change based on how many scores we choose to calculate.
         const idx_t expected_id);
 
 float score_document_by_residuals(

--- a/lintdb/retriever/PlaidRetriever.cpp
+++ b/lintdb/retriever/PlaidRetriever.cpp
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include "lintdb/retriever/PlaidRetriever.h"
+#include "lintdb/retriever/Retriever.h"
 #include "lintdb/plaid.h"
 #include "lintdb/SearchOptions.h"
 #include "lintdb/invlists/EncodedDocument.h"
@@ -17,7 +18,7 @@ namespace lintdb {
         const std::vector<std::unique_ptr<DocumentCodes>>& doc_codes,
         const std::vector<float>& reordered_distances,
         const size_t n,
-        const PlaidOptions& opts
+        const RetrieverOptions& opts
     ) {
         /**
          * score by passage codes
@@ -58,7 +59,7 @@ namespace lintdb {
         const std::unordered_map<idx_t, size_t>& pid_to_index,
         const gsl::span<const float> query_data,
         const size_t n,
-        const PlaidOptions& opts
+        const RetrieverOptions& opts
     ) {
 
         std::vector<std::pair<float, idx_t>> actual_scores(top_25_ids.size());
@@ -103,7 +104,7 @@ namespace lintdb {
         const gsl::span<const float> query_data,
         const size_t n, // num tokens
         const size_t k, // num to return
-        const PlaidOptions& opts
+        const RetrieverOptions& opts
         ) {
 
     auto doc_codes = index_->get_codes(tenant, pid_list);

--- a/lintdb/retriever/PlaidRetriever.cpp
+++ b/lintdb/retriever/PlaidRetriever.cpp
@@ -1,0 +1,194 @@
+#include <omp.h>
+#include "lintdb/retriever/PlaidRetriever.h"
+#include "lintdb/plaid.h"
+#include "lintdb/SearchOptions.h"
+#include "lintdb/invlists/EncodedDocument.h"
+#include <glog/logging.h>
+
+namespace lintdb {
+    PlaidRetriever::PlaidRetriever(
+        std::shared_ptr<ForwardIndex> index,
+        std::shared_ptr<Encoder> encoder
+    ) : index_(index), encoder_(encoder) {
+
+    }
+
+    std::vector<std::pair<float, idx_t>> PlaidRetriever::rank_phase_one(
+        const std::vector<std::unique_ptr<DocumentCodes>>& doc_codes,
+        const std::vector<float>& reordered_distances,
+        const size_t n,
+        const PlaidOptions& opts
+    ) {
+        /**
+         * score by passage codes
+         */
+
+        std::vector<std::pair<float, idx_t>> pid_scores(doc_codes.size());
+
+        #pragma omp for
+        for (int i = 0; i < doc_codes.size(); i++) {
+            auto codes = doc_codes[i]->codes;
+
+            float score = colbert_centroid_score(
+                codes,
+                reordered_distances,
+                n,
+                opts.total_centroids_to_calculate,
+                doc_codes[i]->id
+            );
+            pid_scores[i] = std::pair<float, idx_t>(score, doc_codes[i]->id);
+        }
+
+
+        VLOG(10) << "number of passages to evaluate: " << pid_scores.size();
+        assert(pid_scores.size() == doc_codes.size());
+        // according to the paper, we take the top 25%.
+        std::sort(
+                pid_scores.begin(),
+                pid_scores.end(),
+                std::greater<std::pair<float, idx_t>>());
+
+        return pid_scores;
+    }
+
+     std::vector<std::pair<float, idx_t>> PlaidRetriever::rank_phase_two(
+        const std::vector<idx_t>& top_25_ids,
+        const std::vector<std::unique_ptr<DocumentCodes>>& doc_codes,
+        const std::vector<std::unique_ptr<DocumentResiduals>>& doc_residuals,
+        const std::unordered_map<idx_t, size_t>& pid_to_index,
+        const gsl::span<const float> query_data,
+        const size_t n,
+        const PlaidOptions& opts
+    ) {
+
+        std::vector<std::pair<float, idx_t>> actual_scores(top_25_ids.size());
+#pragma omp for
+    for (int i = 0; i < top_25_ids.size(); i++) {
+        auto residuals = doc_residuals[i]->residuals;
+
+        auto id = doc_residuals[i]->id;
+        auto codes = doc_codes[pid_to_index.at(id)]->codes;
+
+        std::vector<float> decompressed = encoder_->decode_vectors(
+            gsl::span<code_t>(codes),
+            gsl::span<residual_t>(residuals),
+            doc_residuals[i]->num_tokens
+        );
+
+        const auto data_span = gsl::span(query_data.data(), n * encoder_->dim);
+        float score = score_document_by_residuals(
+            data_span,
+            n,
+            decompressed.data(),
+            doc_residuals[i]->num_tokens,
+            encoder_->dim,
+            true);
+
+        actual_scores[i] = std::pair<float, idx_t>(score, top_25_ids[i]);
+    }
+    // according to the paper, we take the top 25%.
+    std::sort(
+        actual_scores.begin(),
+        actual_scores.end(),
+        std::greater<std::pair<float, idx_t>>()
+    );
+
+    return actual_scores;
+    }
+
+    std::vector<SearchResult> PlaidRetriever::retrieve(
+        const idx_t tenant, 
+        const std::vector<idx_t>& pid_list, 
+        const std::vector<float>& reordered_distances,
+        const gsl::span<const float> query_data,
+        const size_t n, // num tokens
+        const size_t k, // num to return
+        const PlaidOptions& opts
+        ) {
+
+    auto doc_codes = index_->get_codes(tenant, pid_list);
+    
+    // create a mapping from pid to the index. we'll need this to hydrate
+    // residuals.
+    std::unordered_map<idx_t, size_t> pid_to_index;
+    for (size_t i = 0; i < doc_codes.size(); i++) {
+        auto id = doc_codes[i]->id;
+        pid_to_index[id] = i;
+    }
+
+    auto pid_scores = rank_phase_one(doc_codes, reordered_distances, n, opts);
+
+    // colBERT has a ndocs param which limits the number of documents to score.
+    size_t cutoff = pid_scores.size();
+    if (opts.num_second_pass != 0 ) {
+        cutoff = opts.num_second_pass;
+    }
+    auto num_rerank = std::max(size_t(1), cutoff / 4);
+    num_rerank = std::min(num_rerank, pid_scores.size());
+
+    if (opts.expected_id != -1) {
+        auto it = std::find_if(
+                pid_scores.begin(),
+                pid_scores.end(),
+                [opts](std::pair<float, idx_t> p) {
+                    return p.second == opts.expected_id;
+                });
+        if (it != pid_scores.end()) {
+            auto pos = it - pid_scores.begin();
+            LOG(INFO) << "found expected id in pid code scores at position: " << pos << " score: " << it->first;
+            if (pos > num_rerank) {
+                LOG(INFO) << "top 25 cutoff: " << num_rerank << ". expected id is not being reranked";
+            }
+        }
+    }
+
+    VLOG(10) << "num to rerank: " << num_rerank;
+    std::vector<std::pair<float, idx_t>> top_25_scores(
+            pid_scores.begin(), pid_scores.begin() + num_rerank);
+
+    /**
+     * score by passage residuals
+     */
+    std::vector<idx_t> top_25_ids;
+    std::transform(
+            top_25_scores.begin(),
+            top_25_scores.end(),
+            std::back_inserter(top_25_ids),
+            [](std::pair<float, idx_t> p) { return p.second; });
+    auto doc_residuals = index_->get_residuals(tenant, top_25_ids);
+
+    auto actual_scores = rank_phase_two(top_25_ids, doc_codes, doc_residuals, pid_to_index, query_data, n, opts);
+
+    if (opts.expected_id != -1) {
+        auto it = std::find_if(
+                actual_scores.begin(),
+                actual_scores.end(),
+                [opts](std::pair<float, idx_t> p) {
+                    return p.second == opts.expected_id;
+                });
+        if (it != actual_scores.end()) {
+            auto pos = it - actual_scores.begin();
+            LOG(INFO) << "expected id found in residual scores: " << pos << " with score: " << it->first;
+            if (pos > num_rerank) {
+                LOG(INFO) << "top 25 cutoff: " << num_rerank << ". expected id has been dropped";
+            }
+        }
+    }
+
+    size_t num_to_return = std::min<size_t>(actual_scores.size(), k);
+    std::vector<std::pair<float, idx_t>> top_k_scores(
+            actual_scores.begin(), actual_scores.begin() + num_to_return);
+
+    std::vector<SearchResult> results;
+    std::transform(
+            top_k_scores.begin(),
+            top_k_scores.end(),
+            std::back_inserter(results),
+            [](std::pair<float, idx_t> p) {
+                return SearchResult{p.second, p.first};
+            });
+
+    return results;
+
+    }
+}

--- a/lintdb/retriever/PlaidRetriever.h
+++ b/lintdb/retriever/PlaidRetriever.h
@@ -1,0 +1,63 @@
+#ifndef LINTDB_RETRIEVER_PLAID_RETRIEVER_H
+#define LINTDB_RETRIEVER_PLAID_RETRIEVER_H
+
+#include <vector>
+#include "lintdb/SearchResult.h"
+#include "lintdb/Encoder.h"
+#include "lintdb/invlists/InvertedList.h"
+#include <stddef.h>
+#include <gsl/span>
+
+namespace lintdb {
+    struct PlaidOptions {
+        const size_t total_centroids_to_calculate;
+        const size_t num_second_pass;
+        const idx_t expected_id;
+        
+    };
+    
+    /**
+     * PlaidRetriever implements the Plaid Engine from: https://arxiv.org/pdf/2205.09707.pdf
+     * 
+     * This is a two-pass retrieval engine that uses a combination of centroid scores and residual scores.
+     * 
+     * Implementation Note: Retrievers depend on both the encoder and the forward index in order to 
+     * get codes and residuals. There's probably a missing abstraction.
+    */
+    struct PlaidRetriever {
+        public:
+        PlaidRetriever(std::shared_ptr<ForwardIndex> index, std::shared_ptr<Encoder> encoder);
+        std::vector<SearchResult> retrieve(
+            const idx_t tenant, 
+            const std::vector<idx_t>& pid_list, 
+            const std::vector<float>& reordered_distances,
+            const gsl::span<const float> query_data,
+            const size_t n, // num tokens
+            const size_t k, // num to return
+            const PlaidOptions& opts
+        );
+
+        private:
+        std::shared_ptr<ForwardIndex> index_;
+        std::shared_ptr<Encoder> encoder_;
+
+        std::vector<std::pair<float, idx_t>> rank_phase_one(
+             const std::vector<std::unique_ptr<DocumentCodes>>&,
+            const std::vector<float>& reordered_distances,
+            const size_t n,
+            const PlaidOptions& opts
+        );
+
+        std::vector<std::pair<float, idx_t>> rank_phase_two(
+            const std::vector<idx_t>& top_25_ids,
+            const std::vector<std::unique_ptr<DocumentCodes>>& doc_codes,
+            const std::vector<std::unique_ptr<DocumentResiduals>>& doc_residuals,
+            const std::unordered_map<idx_t, size_t>& pid_to_index,
+            const gsl::span<const float> query_data,
+            const size_t n,
+            const PlaidOptions& opts
+        );
+    };
+}
+
+#endif

--- a/lintdb/retriever/PlaidRetriever.h
+++ b/lintdb/retriever/PlaidRetriever.h
@@ -5,17 +5,11 @@
 #include "lintdb/SearchResult.h"
 #include "lintdb/Encoder.h"
 #include "lintdb/invlists/InvertedList.h"
+#include "lintdb/retriever/Retriever.h"
 #include <stddef.h>
 #include <gsl/span>
 
-namespace lintdb {
-    struct PlaidOptions {
-        const size_t total_centroids_to_calculate;
-        const size_t num_second_pass;
-        const idx_t expected_id;
-        
-    };
-    
+namespace lintdb {    
     /**
      * PlaidRetriever implements the Plaid Engine from: https://arxiv.org/pdf/2205.09707.pdf
      * 
@@ -24,7 +18,7 @@ namespace lintdb {
      * Implementation Note: Retrievers depend on both the encoder and the forward index in order to 
      * get codes and residuals. There's probably a missing abstraction.
     */
-    struct PlaidRetriever {
+    struct PlaidRetriever: public Retriever {
         public:
         PlaidRetriever(std::shared_ptr<ForwardIndex> index, std::shared_ptr<Encoder> encoder);
         std::vector<SearchResult> retrieve(
@@ -34,7 +28,7 @@ namespace lintdb {
             const gsl::span<const float> query_data,
             const size_t n, // num tokens
             const size_t k, // num to return
-            const PlaidOptions& opts
+            const RetrieverOptions& opts
         );
 
         private:
@@ -45,7 +39,7 @@ namespace lintdb {
              const std::vector<std::unique_ptr<DocumentCodes>>&,
             const std::vector<float>& reordered_distances,
             const size_t n,
-            const PlaidOptions& opts
+            const RetrieverOptions& opts
         );
 
         std::vector<std::pair<float, idx_t>> rank_phase_two(
@@ -55,7 +49,7 @@ namespace lintdb {
             const std::unordered_map<idx_t, size_t>& pid_to_index,
             const gsl::span<const float> query_data,
             const size_t n,
-            const PlaidOptions& opts
+            const RetrieverOptions& opts
         );
     };
 }

--- a/lintdb/retriever/Retriever.h
+++ b/lintdb/retriever/Retriever.h
@@ -1,0 +1,33 @@
+#ifndef LINTDB_RETRIEVER_RETRIEVER_H
+#define LINTDB_RETRIEVER_RETRIEVER_H
+
+#include <vector>
+#include "lintdb/api.h"
+#include "lintdb/SearchResult.h"
+#include <gsl/span>
+
+namespace lintdb {
+    struct RetrieverOptions {
+        const size_t total_centroids_to_calculate;
+        const size_t num_second_pass;
+        const idx_t expected_id;
+    };
+    
+    struct Retriever {
+    public:
+        Retriever() = default;
+        virtual ~Retriever() = default;
+
+        virtual std::vector<SearchResult> retrieve(
+            const idx_t tenant, 
+            const std::vector<idx_t>& pid_list, 
+            const std::vector<float>& reordered_distances,
+            const gsl::span<const float> query_data,
+            const size_t n, // num tokens
+            const size_t k, // num to return
+            const RetrieverOptions& opts
+        ) = 0;
+    };
+}
+
+#endif

--- a/tests/encoder_test.cpp
+++ b/tests/encoder_test.cpp
@@ -75,7 +75,7 @@ TEST(EncoderTest, NoCompressionWorksCorrectly) {
     // our encoded residuals should be the same size they were before encoding, taking the float size into account.
     EXPECT_EQ(encoded_doc->residuals.size(), num_tokens * dim * sizeof(float));
 
-    auto decoded_doc = encoder.decode_vectors(encoded_doc->codes, encoded_doc->residuals, num_tokens, dim);
+    auto decoded_doc = encoder.decode_vectors(encoded_doc->codes, encoded_doc->residuals, num_tokens);
     
     // our decoded doc gives us back the same token embedding size.
     EXPECT_EQ(decoded_doc.size(), num_tokens*dim);


### PR DESCRIPTION
This PR introduces the Retriever interface. Once we know what documents to score, the retriever scores them.

Now that we can swap out retrievers, we're able to implement new ways to score. This could the improvements mentioned in EMVB, or even a binary retriever.

Do note that the interface is not perfect. It feels like there is some overlap with what a query engine might need, and that work might help us figure out the best interface for retrieval.