### PR TITLE
enable gh actions to build multiple python versions

### DIFF
--- a/.github/workflows/build_and_upload_conda.yaml
+++ b/.github/workflows/build_and_upload_conda.yaml
@@ -10,10 +10,6 @@ jobs:
     name: Conda deployment of package with Python ${{ matrix.python-version }}
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-          - os: macos-14
-            python-version: "3.10"
         os: [macos-14, ubuntu-latest]
         python-version: ["3.8, "3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_and_upload_conda.yaml
+++ b/.github/workflows/build_and_upload_conda.yaml
@@ -12,18 +12,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            label: linux-64
-            prefix: /usr/share/miniconda3/envs/my-env
-            python-version: "3.10"
-
           - os: macos-14
-            label: osx-64
-            prefix: /usr/local/miniconda/envs/lintdb-build/conda-bld
             python-version: "3.10"
-
-        # os: [macOS-latest, ubuntu-latest]
-        # # python-version: ["3.8", "3.9", "3.10"]
-        # python-version: ["3.10"]
+        os: [macos-14, ubuntu-latest]
+        python-version: ["3.8, "3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -37,7 +29,6 @@ jobs:
         with:
           activate-environment: lintdb-build
           python-version: ${{ matrix.python-version }}
-          # environment-file: conda/environment.yaml    # Path to the build conda environment
           use-mamba: true
           mamba-version: "*"
           channels: conda-forge,pytorch,defaults

--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -2,7 +2,7 @@ python:
   - 3.9
   - 3.10
   - 3.11
-  - 3.12  # [not aarch64]
+  - 3.12
 MACOSX_SDK_VERSION:         # [osx and x86_64]
   - "10.13"                 # [osx and x86_64]
 MACOSX_DEPLOYMENT_TARGET:   # [osx and x86_64]

--- a/conda/lintdb/meta.yaml
+++ b/conda/lintdb/meta.yaml
@@ -82,6 +82,7 @@ outputs:
         - conda-forge::numpy
         - cmake >=3.23.1
         - make  # [not win]
+        - python {{ python }}
       host:
         - python {{ python }}
         - conda-forge::numpy


### PR DESCRIPTION
Enable multiple version of python for conda packages.

I'm pretty sure there's a more efficient way to do it with conda varaints, but we'll survive for now.