### PR TITLE
Scoring occurs by following the query pattern 1/2

### DIFF
--- a/benchmarks/bench_lintdb.cpp
+++ b/benchmarks/bench_lintdb.cpp
@@ -92,8 +92,8 @@ static void BM_lintdb_search(benchmark::State& state) {
     lintdb::Query query(std::move(root));
 
     lintdb::SearchOptions opts;
-    opts.n_probe = 64;
-    opts.k_top_centroids = 64;
+    opts.n_probe = 32;
+    opts.k_top_centroids = 2;
 
     for(auto _ : state) {
         index.search(0, query, 10, opts);

--- a/lintdb/CMakeLists.txt
+++ b/lintdb/CMakeLists.txt
@@ -28,6 +28,8 @@ set(LINT_DB_SRC
     scoring/plaid.cpp
     query/decode.cpp
         scoring/ContextCollector.cpp
+        scoring/scoring_methods.h
+        scoring/scoring_methods.cpp
 )
 
 set(LINT_DB_HEADERS

--- a/lintdb/index.cpp
+++ b/lintdb/index.cpp
@@ -30,6 +30,7 @@
 #include "lintdb/scoring/Scorer.h"
 #include "lintdb/util.h"
 #include "lintdb/version.h"
+#include "lintdb/scoring/ScoredDocument.h"
 
 namespace lintdb {
 
@@ -376,6 +377,8 @@ std::vector<SearchResult> IndexIVF::search(
 
     VLOG(10) << "preparing search";
     auto fm = field_mapper;
+    // TODO (mbarta): QueryContext is a catch-all that is slowly being phased out.
+    // As we develop more of a query engine, passing around all of this information won't be needed.
     QueryContext context(
             tenant,
             opts.colbert_field,
@@ -383,9 +386,9 @@ std::vector<SearchResult> IndexIVF::search(
             fm,
             coarse_quantizer_map,
             quantizer_map);
-    PlaidScorer scorer(context);
+
     ColBERTScorer ranker(context);
-    QueryExecutor executor(scorer, ranker);
+    QueryExecutor executor(ranker);
 
     VLOG(10) << "executing search";
     std::vector<ScoredDocument> results =

--- a/lintdb/query/DocIterator.cpp
+++ b/lintdb/query/DocIterator.cpp
@@ -130,7 +130,7 @@ void ANNIterator::heapify(size_t idx) {
 ScoredDocument ANNIterator::score(std::vector<DocValue> fields) const {
     score_t score = lintdb::score_embeddings(this->scoring_method, fields, this->knn_);
 
-    return ScoredDocument(score, doc_id(), fields);
+    return ScoredDocument(score, 0, fields);
 }
 
 AndIterator::AndIterator(std::vector<std::unique_ptr<DocIterator>> iterators,

--- a/lintdb/query/DocIterator.h
+++ b/lintdb/query/DocIterator.h
@@ -6,6 +6,11 @@
 #include "lintdb/api.h"
 #include "lintdb/invlists/Iterator.h"
 #include "lintdb/schema/DataTypes.h"
+#include "lintdb/scoring/scoring_methods.h"
+#include "lintdb/scoring/ScoredDocument.h"
+#include "lintdb/invlists/ContextIterator.h"
+#include "lintdb/scoring/ContextCollector.h"
+#include "lintdb/query/KnnNearestCentroids.h"
 
 namespace lintdb {
 /**
@@ -21,6 +26,7 @@ class DocIterator {
 
     virtual idx_t doc_id() const = 0;
     virtual std::vector<DocValue> fields() const = 0;
+    virtual ScoredDocument score(std::vector<DocValue> fields) const = 0;
 
     virtual ~DocIterator() = default;
 };
@@ -34,31 +40,41 @@ class TermIterator : public DocIterator {
     explicit TermIterator(
             std::unique_ptr<Iterator> it,
             DataType type,
+            UnaryScoringMethod scoring_method,
             bool ignore_value = false);
     void advance() override;
     bool is_valid() override;
 
     idx_t doc_id() const override;
     std::vector<DocValue> fields() const override;
+    ScoredDocument score(std::vector<DocValue> fields) const override;
 
    private:
     bool ignore_value;
     DataType type;
+    UnaryScoringMethod scoring_method;
 };
 
 class ANNIterator : public DocIterator {
    public:
-    explicit ANNIterator(std::vector<std::unique_ptr<DocIterator>> its);
+    explicit ANNIterator(std::vector<std::unique_ptr<DocIterator>> its,
+                         ContextCollector context_collector,
+                         std::shared_ptr<KnnNearestCentroids> knn,
+                         EmbeddingScoringMethod scoring_method);
     void advance() override;
     bool is_valid() override;
 
     idx_t doc_id() const override;
     std::vector<DocValue> fields() const override;
+    ScoredDocument score(std::vector<DocValue> fields) const override;
 
    private:
     std::vector<DocValue> fields_;
     std::vector<std::unique_ptr<DocIterator>> its_;
+    ContextCollector context_collector;
+    std::shared_ptr<KnnNearestCentroids> knn_;
     idx_t last_doc_id_;
+    EmbeddingScoringMethod scoring_method;
     void heapify(size_t idx);
 };
 
@@ -67,15 +83,37 @@ class AndIterator : public DocIterator {
     std::vector<std::unique_ptr<DocIterator>> its_;
     idx_t current_doc_id_;
     bool is_valid_;
+    NaryScoringMethod scoring_method;
 
     void synchronize();
 
    public:
-    AndIterator(std::vector<std::unique_ptr<DocIterator>> iterators);
+    AndIterator(std::vector<std::unique_ptr<DocIterator>> iterators,
+                NaryScoringMethod scoring_method);
     void advance() override;
     bool is_valid() override;
     idx_t doc_id() const override;
     std::vector<DocValue> fields() const override;
+    ScoredDocument score(std::vector<DocValue> fields) const override;
+};
+
+class OrIterator : public DocIterator {
+   public:
+    explicit OrIterator(std::vector<std::unique_ptr<DocIterator>> its,
+                        NaryScoringMethod scoring_method);
+    void advance() override;
+    bool is_valid() override;
+
+    idx_t doc_id() const override;
+    std::vector<DocValue> fields() const override;
+    ScoredDocument score(std::vector<DocValue> fields) const override;
+
+   private:
+    std::vector<DocValue> fields_;
+    std::vector<std::unique_ptr<DocIterator>> its_;
+    idx_t last_doc_id_;
+    NaryScoringMethod scoring_method;
+    void heapify(size_t idx);
 };
 
 } // namespace lintdb

--- a/lintdb/query/KnnNearestCentroids.h
+++ b/lintdb/query/KnnNearestCentroids.h
@@ -34,6 +34,10 @@ class KnnNearestCentroids {
         return coarse_idx;
     }
 
+    inline size_t get_num_centroids() const {
+        return num_centroids;
+    }
+
     /// Returns the top centroid id for the idx-th token.
     inline idx_t get_assigned_centroid(size_t idx) const {
         return coarse_idx[idx * total_centroids_to_calculate];

--- a/lintdb/query/QueryExecutor.h
+++ b/lintdb/query/QueryExecutor.h
@@ -8,6 +8,7 @@
 #include "lintdb/SearchResult.h"
 #include "Query.h"
 #include "QueryContext.h"
+#include "lintdb/scoring/ScoredDocument.h"
 
 namespace lintdb {
 /**
@@ -22,7 +23,7 @@ namespace lintdb {
  */
 class QueryExecutor {
    public:
-    QueryExecutor(Scorer& retriever, Scorer& ranker);
+    QueryExecutor(Scorer& ranker);
 
     std::vector<ScoredDocument> execute(
             QueryContext& context,
@@ -31,7 +32,6 @@ class QueryExecutor {
             const SearchOptions& opts);
 
    private:
-    Scorer& retriever;
     Scorer& ranker;
 };
 

--- a/lintdb/scoring/ContextCollector.h
+++ b/lintdb/scoring/ContextCollector.h
@@ -3,8 +3,8 @@
 #include <vector>
 #include <memory>
 #include <string>
-#include "lintdb/query/DocIterator.h"
 #include "lintdb/query/QueryContext.h"
+#include "lintdb/query/DocValue.h"
 #include "lintdb/invlists/ContextIterator.h"
 #include "lintdb/schema/DocEncoder.h"
 #include <glog/logging.h>
@@ -47,7 +47,7 @@ class ContextCollector {
         context_iterators.push_back(std::move(it));
     }
 
-    std::vector<DocValue> get_context_values(const idx_t doc_id) {
+    std::vector<DocValue> get_context_values(const idx_t doc_id) const {
         std::vector<DocValue> results;
         results.reserve(context_iterators.size());
 
@@ -77,6 +77,7 @@ class ContextCollector {
     std::vector<uint8_t> context_field_ids;
     std::vector<DataType> context_data_types;
     std::vector<std::unique_ptr<ContextIterator>> context_iterators;
+
 };
 
 } // namespace lintdb

--- a/lintdb/scoring/ScoredDocument.h
+++ b/lintdb/scoring/ScoredDocument.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <memory>
+#include <vector>
+#include "lintdb/query/DocValue.h"
+
+namespace lintdb {
+struct ScoredDocument {
+    double score = 0;
+    idx_t doc_id = -1;
+    std::vector<lintdb::DocValue>
+            values; /// ScoredDocument takes ownership of the values, because
+    /// we assume we are iterating over a DocIterator and the values are only
+    /// valid for the duration of the iteration.
+
+    ScoredDocument() = default;
+
+    ScoredDocument(float score, idx_t doc_id, std::vector<lintdb::DocValue> values)
+            : score(score), doc_id(doc_id), values(std::move(values)) {}
+
+    bool operator<(const ScoredDocument& other) const {
+        return score < other.score;
+    }
+
+    bool operator>(const ScoredDocument& other) const {
+        return score > other.score;
+    }
+};
+}

--- a/lintdb/scoring/Scorer.cpp
+++ b/lintdb/scoring/Scorer.cpp
@@ -1,9 +1,10 @@
 #include "Scorer.h"
 #include <glog/logging.h>
+#include <algorithm>
 #include "lintdb/invlists/InvertedList.h"
 #include "lintdb/query/decode.h"
 #include "lintdb/schema/DocEncoder.h"
-#include <algorithm>
+#include "ScoredDocument.h"
 
 namespace lintdb {
 ColBERTScorer::ColBERTScorer(const lintdb::QueryContext& context) {}

--- a/lintdb/scoring/Scorer.h
+++ b/lintdb/scoring/Scorer.h
@@ -10,30 +10,9 @@
 #include "lintdb/query/QueryContext.h"
 #include "lintdb/schema/DataTypes.h"
 #include "lintdb/scoring/plaid.h"
+#include "ScoredDocument.h"
 
 namespace lintdb {
-
-struct ScoredDocument {
-    float score = 0;
-    idx_t doc_id = -1;
-    std::vector<DocValue>
-            values; /// ScoredDocument takes ownership of the values, because
-    /// we assume we are iterating over a DocIterator and the values are only
-    /// valid for the duration of the iteration.
-
-    ScoredDocument() = default;
-
-    ScoredDocument(float score, idx_t doc_id, std::vector<DocValue> values)
-            : score(score), doc_id(doc_id), values(std::move(values)) {}
-
-    bool operator<(const ScoredDocument& other) const {
-        return score < other.score;
-    }
-
-    bool operator>(const ScoredDocument& other) const {
-        return score > other.score;
-    }
-};
 
 /**
  * Scorer is an interface for scoring documents.

--- a/lintdb/scoring/scoring_methods.cpp
+++ b/lintdb/scoring/scoring_methods.cpp
@@ -1,0 +1,98 @@
+#include "scoring_methods.h"
+
+namespace lintdb {
+score_t score_one(const std::vector<DocValue>& values) {
+    return 1.0;
+}
+
+score_t plaid_similarity(const std::vector<DocValue>& values, std::shared_ptr<KnnNearestCentroids> knn) {
+    int colbert_idx = -1;
+    for (size_t i = 0; i < values.size(); i++) {
+        if (values[i].type == DataType::COLBERT) {
+            colbert_idx = i;
+            break;
+        }
+    }
+
+    if (colbert_idx == -1) {
+        LOG(WARNING) << "plaid context field not found for doc_id";
+        return 0.0;
+    }
+
+    // rank phase 1: use the codes to score the document using the centroid
+    // scores.
+    auto reordered_distances = knn->get_reordered_distances();
+
+    // gives us a potentially quantized vector
+    SupportedTypes colbert_context = values[colbert_idx].value;
+    ColBERTContextData codes = std::get<ColBERTContextData>(colbert_context);
+    size_t num_tensors = codes.doc_codes.size();
+
+    QueryTensor query = knn->get_query_tensor();
+    float score = colbert_centroid_score(
+            codes.doc_codes,
+            reordered_distances,
+            query.num_query_tokens,
+            knn->get_num_centroids(),
+            -1);
+
+    return score;
+}
+
+UnaryScoringMethodFunction unary_scoring_methods[] = {
+        score_one,
+};
+
+score_t score(const UnaryScoringMethod method, const std::vector<DocValue>& values) {
+    int scoring_type = static_cast<int>(method);
+    return unary_scoring_methods[scoring_type](values);
+}
+
+EmbeddingScoringMethodFunction embedding_scoring_methods[] = {
+        plaid_similarity,
+};
+
+
+score_t score_embeddings(const EmbeddingScoringMethod method, const std::vector<DocValue>& values, std::shared_ptr<KnnNearestCentroids> knn) {
+    int scoring_type = static_cast<int>(method);
+    return embedding_scoring_methods[scoring_type](values, knn);
+}
+
+score_t sum(const std::vector<score_t>& values) {
+    score_t sum = 0;
+    for (const score_t value : values) {
+        sum += value;
+    }
+    return sum;
+}
+
+score_t reduce(const std::vector<score_t>& values) {
+    score_t product = 1;
+    for (const score_t value : values) {
+        product *= value;
+    }
+    return product;
+}
+
+score_t max(const std::vector<score_t>& values) {
+    score_t max = values[0];
+    for (const score_t value : values) {
+        if (value > max) {
+            max = value;
+        }
+    }
+    return max;
+}
+
+NaryScoringMethodFunction nary_scoring_methods[] = {
+        sum,
+        reduce,
+        max,
+};
+
+score_t score(const NaryScoringMethod method, const std::vector<score_t>& values) {
+    int scoring_type = static_cast<int>(method);
+    return nary_scoring_methods[scoring_type](values);
+}
+
+}

--- a/lintdb/scoring/scoring_methods.h
+++ b/lintdb/scoring/scoring_methods.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "lintdb/schema/DataTypes.h"
+#include "lintdb/query/DocValue.h"
+#include "lintdb/query/KnnNearestCentroids.h"
+#include "lintdb/scoring/plaid.h"
+#include <vector>
+#include <string>
+#include <memory>
+
+namespace lintdb {
+
+typedef double score_t;
+typedef score_t (*UnaryScoringMethodFunction)(const std::vector<DocValue>& values);
+typedef score_t (*NaryScoringMethodFunction)(const std::vector<score_t>& values);
+typedef score_t (*EmbeddingScoringMethodFunction)(const std::vector<DocValue>& values, std::shared_ptr<KnnNearestCentroids> knn);
+
+score_t score_one(const std::vector<DocValue>& values);
+
+score_t plaid_similarity(const std::vector<DocValue>& values, std::shared_ptr<KnnNearestCentroids> knn);
+
+
+enum class UnaryScoringMethod {
+    ONE = 0,
+};
+
+score_t score(const UnaryScoringMethod method, const std::vector<DocValue>& values);
+
+enum class EmbeddingScoringMethod {
+    PLAID = 1,
+    COLBERT = 2
+};
+
+score_t score_embeddings(const EmbeddingScoringMethod method, const std::vector<DocValue>& values, std::shared_ptr<KnnNearestCentroids> knn);
+
+score_t sum(const std::vector<score_t>& values);
+
+score_t reduce(const std::vector<score_t>& values);
+
+score_t max(const std::vector<score_t>& values);
+
+enum class NaryScoringMethod {
+    SUM = 0,
+    REDUCE = 1,
+    MAX = 2,
+};
+score_t score(const NaryScoringMethod method, const std::vector<score_t>& values);
+
+}


### PR DESCRIPTION
A user should be able to craft scoring algorithms in a more flexible manner than having to define it through options.

To work towards that point, we've decided that a query can include the scoring operator. When querying, a user then has control over how the queries get scored.

maxsim then looks much more similar to how vespa defines their scoring:
```
sum(
    reduce(
        sum(
            max(
                token_sim(field_value("colbert", [1,2,3]))
            )
        )
    )
)
```

Unlike vespa, this isn't a separate scoring profiling defined with the schema. Scoring can be done at query time at the cost of runtime errors for mismatching dependencies in the query.