### PR TITLE
Pass data out of KnnNearestCentroids by reference

### DIFF
--- a/lintdb/query/KnnNearestCentroids.h
+++ b/lintdb/query/KnnNearestCentroids.h
@@ -9,7 +9,7 @@
 namespace lintdb {
 
 struct QueryTensor {
-    std::vector<float> query;
+    const std::vector<float>& query;
     size_t num_query_tokens;
 };
 
@@ -43,7 +43,7 @@ class KnnNearestCentroids {
         return coarse_idx[idx * total_centroids_to_calculate];
     }
 
-    inline std::vector<float> get_reordered_distances() const {
+    inline const std::vector<float>& get_reordered_distances() const {
         return reordered_distances;
     }
 

--- a/lintdb/scoring/Scorer.cpp
+++ b/lintdb/scoring/Scorer.cpp
@@ -47,7 +47,7 @@ ScoredDocument ColBERTScorer::score(
             context.getOrCreateNearestCentroids(context.colbert_context)
                     ->get_query_tensor();
 
-    auto query_span = gsl::span<float>(query.query);
+    auto query_span = gsl::span<const float>(query.query);
 
     DocumentScore score = score_document_by_residuals(
             query_span,


### PR DESCRIPTION
We pass back the values in KnnNearestCentroids by reference.

Profiling suggested that we are spending a lot of time copying data from this class, which isn't intended.